### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+context (2020.03.10.20200331-2) UNRELEASED; urgency=medium
+
+  * Add missing build dependency on dh addon.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:12:38 +0000
+
 context (2020.03.10.20200331-1) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 context (2020.03.10.20200331-2) UNRELEASED; urgency=medium
 
   * Add missing build dependency on dh addon.
+  * Set upstream metadata fields: Repository.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:12:38 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: tex
 Priority: optional
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>
-Build-Depends: debhelper-compat (= 12)
+Build-Depends: debhelper-compat (= 12), tex-common
 Build-Depends-Indep: tex-common (>= 6)
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/context.git

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,1 @@
+Repository: https://bitbucket.org/phg/context-mirror.git,branch=beta


### PR DESCRIPTION
Fix some issues reported by lintian
* Add missing build dependency on dh addon. ([missing-build-dependency-for-dh_command](https://lintian.debian.org/tags/missing-build-dependency-for-dh_command.html))
* Set upstream metadata fields: Repository. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/context/7107bff6-8b73-4a61-9bb4-27f1bf3a6e17.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/7107bff6-8b73-4a61-9bb4-27f1bf3a6e17/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/7107bff6-8b73-4a61-9bb4-27f1bf3a6e17/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/7107bff6-8b73-4a61-9bb4-27f1bf3a6e17/diffoscope)).
