### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -6,6 +6,9 @@ context (2020.03.10.20200331-2) UNRELEASED; urgency=medium
   * Add missing build dependency on dh addon.
   * Set upstream metadata fields: Repository.
 
+  [ Debian Janitor ]
+  * Remove 1 obsolete maintscript entry.
+
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:12:38 +0000
 
 context (2020.03.10.20200331-1) unstable; urgency=medium

--- a/debian/changelog
+++ b/debian/changelog
@@ -8,6 +8,7 @@ context (2020.03.10.20200331-2) UNRELEASED; urgency=medium
 
   [ Debian Janitor ]
   * Remove 1 obsolete maintscript entry.
+  * Bump debhelper from old 12 to 13.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:12:38 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -9,6 +9,7 @@ context (2020.03.10.20200331-2) UNRELEASED; urgency=medium
   [ Debian Janitor ]
   * Remove 1 obsolete maintscript entry.
   * Bump debhelper from old 12 to 13.
+  * Remove Section on context that duplicates source.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:12:38 +0000
 

--- a/debian/context.maintscript
+++ b/debian/context.maintscript
@@ -1,1 +1,0 @@
-rm_conffile /etc/texmf/fmt.d/20context.cnf 2015.05.18.20150601-1~

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,6 @@ Vcs-Git: https://github.com/debian-tex/context.git
 Vcs-Browser: https://github.com/debian-tex/context
 
 Package: context
-Section: tex
 Architecture: all
 Depends: ruby | ruby-interpreter, texlive-binaries (>= 2019), texlive-base (>= 2019), texlive-metapost (>= 2019), lmodern (>= 2.004.4), tex-gyre, ${misc:Depends}
 Recommends: fonts-gfs-artemisia, fonts-gfs-baskerville, fonts-gfs-bodoni-classic, fonts-gfs-didot-classic, fonts-gfs-didot, fonts-gfs-olga, fonts-gfs-porson, fonts-gfs-gazis, fonts-gfs-neohellenic, fonts-gfs-solomos, fonts-gfs-theokritos, fonts-freefont, fonts-sil-gentium, context-modules

--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,7 @@ Priority: optional
 Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
 	   Hilmar Preusse <hille42@web.de>
-Build-Depends: debhelper-compat (= 12), tex-common
+Build-Depends: debhelper-compat (= 13), tex-common
 Build-Depends-Indep: tex-common (>= 6)
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/context.git


### PR DESCRIPTION
Fix some issues reported by lintian

* Remove 1 obsolete maintscript entry.

* Bump debhelper from old 12 to 13. ([package-uses-old-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-old-debhelper-compat-version))

* Remove Section on context that duplicates source. ([binary-control-field-duplicates-source](https://lintian.debian.org/tags/binary-control-field-duplicates-source))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/context/43b18a40-2a95-460e-936f-0ead2461aaa5.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in first set of .debs but not in second
    -rwxr-xr-x  root/root   DEBIAN/prerm

No differences were encountered in the control files


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/43b18a40-2a95-460e-936f-0ead2461aaa5/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/43b18a40-2a95-460e-936f-0ead2461aaa5/diffoscope)).
