### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -10,6 +10,10 @@ context (2020.03.10.20200331-2) UNRELEASED; urgency=medium
   * Remove 1 obsolete maintscript entry.
   * Bump debhelper from old 12 to 13.
   * Remove Section on context that duplicates source.
+  * Remove constraints unnecessary since buster:
+    + Build-Depends-Indep: Drop versioned constraint on tex-common.
+    + context: Drop versioned constraint on lmodern in Depends.
+    + context: Drop versioned constraint on texlive-xetex in Conflicts.
 
  -- Debian Janitor <janitor@jelmer.uk>  Wed, 06 May 2020 08:12:38 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -5,17 +5,17 @@ Maintainer: Debian TeX maintainers <debian-tex-maint@lists.debian.org>
 Uploaders: Norbert Preining <norbert@preining.info>,
 	   Hilmar Preusse <hille42@web.de>
 Build-Depends: debhelper-compat (= 13), tex-common
-Build-Depends-Indep: tex-common (>= 6)
+Build-Depends-Indep: tex-common
 Standards-Version: 4.2.1
 Vcs-Git: https://github.com/debian-tex/context.git
 Vcs-Browser: https://github.com/debian-tex/context
 
 Package: context
 Architecture: all
-Depends: ruby | ruby-interpreter, texlive-binaries (>= 2019), texlive-base (>= 2019), texlive-metapost (>= 2019), lmodern (>= 2.004.4), tex-gyre, ${misc:Depends}
+Depends: ruby | ruby-interpreter, texlive-binaries (>= 2019), texlive-base (>= 2019), texlive-metapost (>= 2019), lmodern, tex-gyre, ${misc:Depends}
 Recommends: fonts-gfs-artemisia, fonts-gfs-baskerville, fonts-gfs-bodoni-classic, fonts-gfs-didot-classic, fonts-gfs-didot, fonts-gfs-olga, fonts-gfs-porson, fonts-gfs-gazis, fonts-gfs-neohellenic, fonts-gfs-solomos, fonts-gfs-theokritos, fonts-freefont, fonts-sil-gentium, context-modules
 Suggests: perl-tk, libxml-parser-perl, fontforge, context-nonfree
-Conflicts: texlive-context, tetex-bin (<< 2007), texlive-xetex (<< 2009)
+Conflicts: texlive-context, tetex-bin (<< 2007)
 Replaces: texlive-context
 Provides: texlive-context
 Description: powerful TeX format


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/context/564d0b45-fff6-4bbf-b53a-9bc7abe90c88.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files: lines which differ (wdiff format)
* Conflicts: tetex-bin (<< 2007), [-texlive-context, texlive-xetex (<< 2009)-] {+texlive-context+}
* Depends: ruby | ruby-interpreter, texlive-binaries (>= 2019), texlive-base (>= 2019), texlive-metapost (>= 2019), [-lmodern (>= 2.004.4),-] {+lmodern,+} tex-gyre, tex-common (>= 6.13)


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/564d0b45-fff6-4bbf-b53a-9bc7abe90c88/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/564d0b45-fff6-4bbf-b53a-9bc7abe90c88/diffoscope)).
